### PR TITLE
Fix initialize warning

### DIFF
--- a/src/read_modes.tpp
+++ b/src/read_modes.tpp
@@ -4,7 +4,7 @@
 
 template <typename VT>
 ReadModes<VT>::ReadModes(std::string filename, bool is_ocean, bool allmodes)
-    : m_filename(filename), is_HOS_Ocean(is_ocean), is_init(true)
+    : m_filename(filename), is_init(true), is_HOS_Ocean(is_ocean)
 {
     // Set time index value
     itime_now = 0;


### PR DESCRIPTION
fixes:
```
In file included from /Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.h:218:
/Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.tpp:7:29: warning: field 'is_HOS_Ocean' will be initialized after field 'is_init' [-Wreorder-ctor]
    7 |     : m_filename(filename), is_HOS_Ocean(is_ocean), is_init(true)
      |                             ^~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~
      |                             is_init(true            is_HOS_Ocean(is_ocean
/Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.cpp:3:16: note: in instantiation of member function 'ReadModes<double>::ReadModes' requested here
    3 | template class ReadModes<double>;
      |                ^
In file included from /Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.cpp:1:
In file included from /Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.h:218:
/Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.tpp:7:29: warning: field 'is_HOS_Ocean' will be initialized after field 'is_init' [-Wreorder-ctor]
    7 |     : m_filename(filename), is_HOS_Ocean(is_ocean), is_init(true)
      |                             ^~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~
      |                             is_init(true            is_HOS_Ocean(is_ocean
/Users/mhenryde/exawind/source/amr-wind/submods/Waves2AMR/src/read_modes.cpp:4:16: note: in instantiation of member function 'ReadModes<std::complex<double>>::ReadModes' requested here
    4 | template class ReadModes<std::complex<double>>;
 ```