### PR TITLE
Readd POSITION_INDEPENDENT_CODE for shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ if (WAVES2AMR_GPU_BACKEND STREQUAL "CUDA")
 endif ()
 
 add_library(waves_2_amr OBJECT)
+if (BUILD_SHARED_LIBS)
+  set_target_properties(waves_2_amr PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 target_link_libraries(waves_2_amr PUBLIC AMReX::amrex)
 
 find_package(FFTW REQUIRED)


### PR DESCRIPTION
This fixes:
```
5 errors found in build log:
     622    [ 35%] Built target ftime
     623    /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/compiler-wrapper-1.0-4ozd6rhxuipkdmlr52gd2lhtty6a77c3/libexec/spack/clang/clang++ -O3 -DNDEBUG -Wl,-rpath -Wl,/mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/mpich-4.3.2-7ojfifruhxjom3tolcjmt6tlvmwegoeo/lib -Xlinker --dependency-file=CMakeFiles/fnan.dir/link.d CMakeFiles/fnan.dir/fnan.cpp.o -o amrex_fnan  -Wl,-r
            path,/mnt/vdb/home/mhenryde/exawind/exawind-manager/stage/spack-stage-amr-wind-main-gyyfz3zxmccv77cqxofc7yui2net3vr3/spack-build-gyyfz3z/submods/amrex/Src:/mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/mpich-4.3.2-7ojfifruhxjom3tolcjmt6tlvmwegoeo/lib:/mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/hdf5-1.14.4-3-glejiacwb2ttyj2yjpz7thhol754dn3g/lib:/mnt/vdb/h
            ome/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/zfp-1.0.1-bxtv4i46wxqjg7jjuh74t3gwrnwkvfmr/lib64:/mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/zlib-ng-2.2.4-xwpcucrxamz5bfbccrkbegxqz3lqd2rs/lib:/mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/hypre-2.32.0-washjflpk227ccjvwkqhfi7vvch5hd3z/lib::::::::::::::::::::::::::::::::::::::::::::::::::::
            :::::::::::::::::::::::::::::::::::::::::::::::::: ../../Src/libamrex_3d.so -pthread /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/mpich-4.3.2-7ojfifruhxjom3tolcjmt6tlvmwegoeo/lib/libmpicxx.so /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/hdf5-1.14.4-3-glejiacwb2ttyj2yjpz7thhol754dn3g/lib/libhdf5.so /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt
            /spack/linux-zen2/h5z-zfp-1.1.1-gy6si5nlaqw6mzsctmawlalzonz3gccz/lib/libh5zzfp.a /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/zfp-1.0.1-bxtv4i46wxqjg7jjuh74t3gwrnwkvfmr/lib64/libzfp.so.1.0.1 /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/hdf5-1.14.4-3-glejiacwb2ttyj2yjpz7thhol754dn3g/lib/libhdf5.a -lm -ldl /mnt/vdb/home/mhenryde/exawind/exawind-manager/sp
            ack/opt/spack/linux-zen2/zlib-ng-2.2.4-xwpcucrxamz5bfbccrkbegxqz3lqd2rs/lib/libz.so -ldl /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/zlib-ng-2.2.4-xwpcucrxamz5bfbccrkbegxqz3lqd2rs/lib/libz.so /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/spack/linux-zen2/mpich-4.3.2-7ojfifruhxjom3tolcjmt6tlvmwegoeo/lib/libmpi.so /mnt/vdb/home/mhenryde/exawind/exawind-manager/spack/opt/s
            pack/linux-zen2/hypre-2.32.0-washjflpk227ccjvwkqhfi7vvch5hd3z/lib/libHYPRE.so
     624    make[2]: Leaving directory '/mnt/vdb/home/mhenryde/exawind/exawind-manager/stage/spack-stage-amr-wind-main-gyyfz3zxmccv77cqxofc7yui2net3vr3/spack-build-gyyfz3z'
     625    [ 35%] Built target fnan
     626    /data/ssd1/software/2024-05-01/opt/compilers/linux-rocky8-zen2/gcc-12.3.0/binutils-2.42-vsbisf6knss7iqk32du6cl5nkruhp2tc/bin/ld: CMakeFiles/waves_2_amr.dir/src/interp_to_mfab.cpp.o: warning: relocation against `_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits' in read-only section `.text'
     627    /data/ssd1/software/2024-05-01/opt/compilers/linux-rocky8-zen2/gcc-12.3.0/binutils-2.42-vsbisf6knss7iqk32du6cl5nkruhp2tc/bin/ld: CMakeFiles/waves_2_amr.dir/src/interp_to_mfab.cpp.o: relocation R_X86_64_PC32 against symbol `_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits' can not be used when making a shared object; recompile with -fPIC
  >> 628    /data/ssd1/software/2024-05-01/opt/compilers/linux-rocky8-zen2/gcc-12.3.0/binutils-2.42-vsbisf6knss7iqk32du6cl5nkruhp2tc/bin/ld: final link failed: bad value
  ```

on ellis.